### PR TITLE
wrote dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM tensorflow/tensorflow:1.14.0-gpu-py3
+WORKDIR /cerebrum7t
+COPY requirements.txt .
+RUN pip install -r requirements.txt && apt update && apt install -y libsm6 libxext6 libxrender-dev
+COPY . .


### PR DESCRIPTION
The [docs](https://rocknroll87q.github.io/cerebrum7t/usage) say you should be able to do `docker pull rocknroll87q/cerebrum7t`, but that doesn't work
```
$ docker pull rocknroll87q/cerebrum7t
Using default tag: latest
Error response from daemon: manifest for rocknroll87q/cerebrum7t:latest not found: manifest unknown: manifest unknown
```
So I wrote my own Dockerfile. I realized I actually can't pull it because there's no latest tag, but either way it would be nice if the Dockerfile were included in the source repository.